### PR TITLE
Move the trap of TERM signals before sleep

### DIFF
--- a/cloe_run
+++ b/cloe_run
@@ -231,6 +231,14 @@ do
     set_cloe_status ${MSG}
     sleep ${SLEEP}
   fi
+  
+  if [[ ! -z ${TERM_SIGNALED} ]]; then
+    cloe_run_parts "${CLOE_RUN_SYSTEM_CONF_DIR}/last-run.d" |& eval ${PIPECMD}
+    MSG="Finished because of TERM signal received."
+    echo ${MSG} |& eval ${PIPECMD}
+    set_cloe_status ${MSG}
+    exit 0
+  fi
 
 done
 

--- a/cloe_run
+++ b/cloe_run
@@ -216,20 +216,20 @@ do
     set_cloe_status ${MSG}
     exit 0
   fi
-
-  if [[ ! -z ${SLEEP} ]]; then
-    MSG="Sleeping for ${SLEEP}..."
-    echo ${MSG} |& eval ${PIPECMD}
-    set_cloe_status ${MSG}
-    sleep ${SLEEP}
-  fi
-
+  
   if [[ ! -z ${TERM_SIGNALED} ]]; then
     cloe_run_parts "${CLOE_RUN_SYSTEM_CONF_DIR}/last-run.d" |& eval ${PIPECMD}
     MSG="Finished because of TERM signal received."
     echo ${MSG} |& eval ${PIPECMD}
     set_cloe_status ${MSG}
     exit 0
+  fi
+
+  if [[ ! -z ${SLEEP} ]]; then
+    MSG="Sleeping for ${SLEEP}..."
+    echo ${MSG} |& eval ${PIPECMD}
+    set_cloe_status ${MSG}
+    sleep ${SLEEP}
   fi
 
 done


### PR DESCRIPTION
With trap before sleep `cloe_run` will be able to receive TERM signals no matter the `sleep` setted on the conf.
